### PR TITLE
Ship binaries that can actually generate a report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
           --output-dir=dist
           --output-filename=tembench
           --include-package=tembench
+          --include-package-data=tembench
           --include-package-data=altair
           --enable-plugin=anti-bloat
           build/tembench_entry.py
@@ -76,6 +77,7 @@ jobs:
           --output-dir=dist
           --output-filename=tembench_entry
           --include-package=tembench
+          --include-package-data=tembench
           --include-package-data=altair
           --enable-plugin=anti-bloat
           --windows-console-mode=force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,39 @@ jobs:
           python -m pip install -e .
           python -m pip install "nuitka>=2.5" ordered-set zstandard
 
+      - name: Check the tag matches the packaged version
+        shell: python
+        run: |
+          import os
+          import sys
+
+          import tembench
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          expected = tembench.__version__
+          if tag.lstrip("v") != expected:
+              print(
+                  f"Tag {tag!r} does not match __version__ {expected!r}. "
+                  "Releasing them out of step ships binaries that misreport "
+                  "which version they are."
+              )
+              sys.exit(1)
+          print(f"Tag {tag} matches version {expected}")
+
       - name: Create Nuitka entrypoint
         shell: python
         run: |
           from pathlib import Path
           Path("build").mkdir(exist_ok=True)
+          # The import stays inside the __main__ guard: Nuitka re-executes the
+          # entry module in the compiled binary, and importing at module level
+          # has broken this build before (see build.yml, which matches).
           Path("build/tembench_entry.py").write_text(
-              "from tembench.cli import app\n\n"
+              "#!/usr/bin/env python3\n"
+              "# -*- coding: utf-8 -*-\n"
+              "import sys\n"
               "if __name__ == '__main__':\n"
+              "    from tembench.cli import app\n"
               "    app()\n",
               encoding="utf-8",
           )
@@ -61,6 +86,7 @@ jobs:
           --output-dir=dist
           --output-filename=tembench
           --include-package=tembench
+          --include-package-data=tembench
           --include-package-data=altair
           build/tembench_entry.py
 
@@ -73,10 +99,76 @@ jobs:
           --output-dir=dist
           --output-filename=tembench
           --include-package=tembench
+          --include-package-data=tembench
           --include-package-data=altair
           --windows-console-mode=force
           --mingw64
           build/tembench_entry.py
+
+      - name: Smoke test the executable
+        shell: python
+        run: |
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          runner_os = os.environ["RUNNER_OS"]
+          exe = (
+              Path("dist/tembench.dist/tembench.exe")
+              if runner_os == "Windows"
+              else Path("dist/tembench")
+          )
+          if not exe.is_file():
+              print(f"No executable at {exe}")
+              sys.exit(1)
+
+          env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+
+          def run(*args: str) -> subprocess.CompletedProcess:
+              print(f"$ {exe} {' '.join(args)}")
+              result = subprocess.run(
+                  [str(exe), *args], capture_output=True, text=True,
+                  encoding="utf-8", errors="replace", timeout=300, env=env,
+              )
+              print(result.stdout[-4000:])
+              if result.returncode != 0:
+                  print(result.stderr[-4000:])
+              return result
+
+          if run("--help").returncode != 0:
+              print("The binary does not start.")
+              sys.exit(1)
+
+          # `--help` never touches the packaged CSS/JS or altair's schema data,
+          # so it cannot tell a working binary from one missing its data files.
+          # Generating a chart and a report does.
+          work = Path("smoke")
+          work.mkdir(exist_ok=True)
+          (work / "summary.csv").write_text(
+              "bench,impl,n,time_ms_median,time_ms_count,time_ms_p10,time_ms_p90\n"
+              "b,a,100,1.0,5,0.9,1.1\n"
+              "b,a,200,2.1,5,2.0,2.2\n"
+              "b,a,400,4.0,5,3.9,4.1\n"
+              "b,a,800,8.2,5,8.0,8.4\n",
+              encoding="utf-8",
+          )
+
+          if run("plot", "--summary", str(work / "summary.csv"),
+                 "--out-html", str(work / "runtime.html")).returncode != 0:
+              print("Chart generation failed — altair data files are likely missing.")
+              sys.exit(1)
+
+          if run("report", "--summary", str(work / "summary.csv"),
+                 "--output", str(work / "report.html")).returncode != 0:
+              print("Report generation failed — packaged assets are likely missing.")
+              sys.exit(1)
+
+          report = (work / "report.html").read_text(encoding="utf-8")
+          if "sysinfo-grid" not in report or "theme-toggle" not in report:
+              print("Report is missing its packaged stylesheet or script.")
+              sys.exit(1)
+          print(f"Report OK ({len(report)} bytes)")
 
       - name: Package artifact
         shell: python
@@ -156,4 +248,6 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
           files: release/tembench-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## 0.1.0
+
+First release.
+
+TempoBench runs any shell command over a parameter sweep, records timing and
+memory, estimates a Big-O class from the result, and reports how much the
+measurements actually support that class.
+
+### Measuring
+
+- Parameter sweeps over arbitrary grids, with configurable repeats, warm-ups,
+  timeouts, and optional parallel execution.
+- Wall-clock time and peak RSS per trial, with Tukey outlier filtering.
+- **Self-reported timing.** A command can print `TEMPOBENCH_MS: <ms>` to have
+  its own hot section measured instead of the whole process. Process startup is
+  a constant added to every reading, and a constant is what destroys a
+  complexity fit — on the bundled example, wall clock reports O(n) for two
+  implementations that self-reported timing correctly separates into O(n log n)
+  and O(n).
+- `{python}` expands to the running interpreter, so configs are portable.
+
+### Reporting a class honestly
+
+- Candidate models: O(1), O(log n), O(√n), O(n), O(n log n), O(n²), O(n³),
+  O(n² 2ⁿ).
+- Every fit carries a confidence rating and the specific caveats behind it:
+  too few input sizes, too narrow a range, a flat signal, a wide exponent
+  interval, constant overhead dominating the readings, a rival class that fits
+  equally well, too few trials per point, or trials that disagree with each
+  other.
+- The runner-up class and its margin are reported, so a coin flip between two
+  classes reads as one.
+
+### Running in CI
+
+- Failed runs, empty summaries, and regressions exit non-zero; failures are
+  reported with the command's own message rather than a count.
+- `tembench validate` checks a config and trial-runs its cheapest grid point in
+  seconds, catching typos, missing interpreters, thin protocols, and configs
+  that would silently fall back to wall-clock timing.
+- Provenance records the machine that ran the benchmark, and reports read it
+  back — so a report built elsewhere still describes where the numbers came
+  from.
+
+### Known limitations
+
+- Empirical complexity measures the machine, not the algorithm. Once an input
+  stops fitting in cache, the memory hierarchy sets the pace; the README
+  documents this in "What a measured class does and does not mean".
+- Sweeps must run on an idle machine. Contention produces smooth, wrong curves;
+  TempoBench flags unrepeatable trials but cannot recover the measurement.
+- Tests run on Linux in CI. Windows and macOS binaries are built and smoke
+  tested, but the test suite is not run on them.
+- The package and command are named `tembench`, while the project is
+  TempoBench.

--- a/tests/test_reported.py
+++ b/tests/test_reported.py
@@ -136,42 +136,52 @@ def test_interrupting_a_trial_kills_the_child(tmp_path: Path, monkeypatch):
     """Ctrl-C must not hang on the current trial, nor orphan it.
 
     The child runs in its own process group so terminal signals never reach it;
-    if the runner does not kill it explicitly, a long benchmark keeps running
-    with nothing watching it.
+    if the runner does not kill it explicitly, `Popen.__exit__` merely waits and
+    a long benchmark keeps running with nothing watching it.
     """
     import time as _time
+    from types import SimpleNamespace
 
     import psutil
 
     import tembench.runner.process as process_mod
 
-    script = _script(tmp_path, """
-        import time
+    pidfile = tmp_path / "child.pid"
+    script = _script(tmp_path, f"""
+        import os, time
+        open({str(pidfile)!r}, "w").write(str(os.getpid()))
         time.sleep(60)
     """)
 
-    seen: list[int] = []
     real_sleep = _time.sleep
 
-    def interrupt_during_monitoring(seconds):
-        # The runner polls in a sleep loop; a Ctrl-C lands here, not in wait().
-        raise KeyboardInterrupt
+    def interrupt_once_the_child_is_up(seconds):
+        # A Ctrl-C lands in the runner's polling sleep, not in wait().
+        if pidfile.exists():
+            raise KeyboardInterrupt
+        real_sleep(seconds)
 
-    def capture_pid(pid):
-        seen.append(pid)
-        return psutil.Process(pid)
-
-    monkeypatch.setattr(process_mod.time, "sleep", interrupt_during_monitoring)
-    monkeypatch.setattr(process_mod.psutil, "Process", capture_pid)
+    # Rebind the module's own `time` name rather than patching the real time
+    # module: setattr on the module object is global, so subprocess's internal
+    # sleeps would raise too while the runner is terminating the child.
+    monkeypatch.setattr(
+        process_mod,
+        "time",
+        SimpleNamespace(
+            perf_counter=_time.perf_counter, sleep=interrupt_once_the_child_is_up
+        ),
+    )
 
     with pytest.raises(KeyboardInterrupt):
         run_once(f"{sys.executable} {script}", {}, None, None, 0.01)
 
-    assert seen, "the child never started"
+    child_pid = int(pidfile.read_text())
     deadline = _time.time() + 10
     while _time.time() < deadline:
-        if not psutil.pid_exists(seen[0]) or psutil.Process(seen[0]).status() == psutil.STATUS_ZOMBIE:
+        if not psutil.pid_exists(child_pid):
+            break
+        if psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE:
             break
         real_sleep(0.1)
     else:
-        raise AssertionError("child survived the interrupt")
+        raise AssertionError(f"child {child_pid} survived the interrupt")


### PR DESCRIPTION
`tembench report` is broken in every executable this project has built. The assets it needs — report.css and theme-toggle.js — are loaded at runtime through importlib.resources, and Nuitka does not bundle package data unless told to. Neither workflow passed --include-package-data=tembench, so the binary starts, prints --help, plots a chart, and then dies:

    NotADirectoryError: .../tembench/reporting/assets/report.css

Verified locally by building with the workflows' exact flags.

- Add --include-package-data=tembench to both build and release workflows.
- Smoke test the built binary in release.yml, and make the test actually exercise the data files: --help touches neither the packaged assets nor altair's schema, so it cannot tell a working binary from a broken one. The new test renders a chart and a report and checks the stylesheet and script made it into the output.
- Align the release entrypoint with build.yml's, keeping the import inside the __main__ guard. Two earlier commits fixed exactly that for Nuitka; release.yml still carried the module-level form.
- Fail the release if the tag does not match __version__, so binaries cannot misreport which version they are.
- Generate release notes and fail if no artifacts matched.

Also fixes a test I introduced that was flaky under load: it patched sleep on the real time module, which made subprocess's internal sleeps raise while the runner was terminating a child. It now rebinds only the name inside the module under test, and identifies the child from a pidfile instead of monkeypatching psutil (whose internals need Process to stay a type). Fails in 10s without the fix under test, passes in 0.05s with it.