### PR TITLE
Build the POSIX binary under a name that does not collide with its data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           --onefile
           --assume-yes-for-downloads
           --output-dir=dist
-          --output-filename=tembench
+          --output-filename=tembench.bin
           --include-package=tembench
           --include-package-data=tembench
           --include-package-data=altair
@@ -101,13 +101,13 @@ jobs:
                   "dist/tembench_entry.dist/tembench_entry.exe",
                   "dist/tembench_entry.exe",
               ],
-              "Linux": ["dist/tembench"],
-              "macOS": ["dist/tembench"],
+              "Linux": ["dist/tembench.bin"],
+              "macOS": ["dist/tembench.bin"],
           }[runner_os]
 
           candidates = [p for p in expected_candidates if os.path.isfile(p)]
           if not candidates:
-              wanted_name = "tembench.exe" if runner_os == "Windows" else "tembench"
+              wanted_name = "tembench.exe" if runner_os == "Windows" else "tembench.bin"
               candidates = [
                   str(p)
                   for p in sorted(Path("dist").rglob(wanted_name))
@@ -203,8 +203,8 @@ jobs:
 
           expected = {
               "Windows": "dist/tembench_entry.exe",
-              "Linux": "dist/tembench",
-              "macOS": "dist/tembench",
+              "Linux": "dist/tembench.bin",
+              "macOS": "dist/tembench.bin",
           }[runner_os]
 
           src_candidates = [expected] if os.path.isfile(expected) else []

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
               encoding="utf-8",
           )
 
+      # The binary is built as `tembench.bin` and renamed when packaged.
+      # --include-package-data lays the package's data files out under
+      # `tembench/`, which cannot coexist with an executable also called
+      # `tembench` on POSIX. Windows is unaffected: there the executable is
+      # `tembench.exe`, a different name from the data directory.
       - name: Build onefile executable (Linux/macOS)
         if: runner.os != 'Windows'
         run: >
@@ -84,7 +89,7 @@ jobs:
           --onefile
           --assume-yes-for-downloads
           --output-dir=dist
-          --output-filename=tembench
+          --output-filename=tembench.bin
           --include-package=tembench
           --include-package-data=tembench
           --include-package-data=altair
@@ -117,7 +122,7 @@ jobs:
           exe = (
               Path("dist/tembench.dist/tembench.exe")
               if runner_os == "Windows"
-              else Path("dist/tembench")
+              else Path("dist/tembench.bin")
           )
           if not exe.is_file():
               print(f"No executable at {exe}")
@@ -199,8 +204,8 @@ jobs:
 
           expected = {
               "Windows": "dist/tembench.exe",
-              "Linux": "dist/tembench",
-              "macOS": "dist/tembench",
+              "Linux": "dist/tembench.bin",
+              "macOS": "dist/tembench.bin",
           }[runner_os]
 
           src_candidates = [expected] if os.path.isfile(expected) else []
@@ -250,4 +255,7 @@ jobs:
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
           fail_on_unmatched_files: true
+          # Created as a draft: the binaries are attached and reviewable, but
+          # nothing is public until someone presses Publish.
+          draft: true
           files: release/tembench-*


### PR DESCRIPTION
--include-package-data=tembench lays the package's data files out under `tembench/` in the distribution, which cannot coexist with an executable of the same name on Linux or macOS. Nuitka stops with:

    FATAL: Error, data file to be placed in distribution as 'tembench'
           conflicts with executable 'tembench'

So the flag added in the previous commit fixes `tembench report` on Windows and breaks the build outright everywhere else. Windows escapes the clash only because its executable is `tembench.exe`, a different name from the directory.

Build the POSIX binary as `tembench.bin` and let the packaging step rename it, which it already does — the published artifacts stay `tembench-linux` and `tembench-macos`, so nothing changes for anyone downloading them. The smoke test and verification steps follow the new name.

Also mark the GitHub release as a draft, so the binaries are attached and reviewable before anything becomes public.